### PR TITLE
docs: add compose environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TZ=Asia/Shanghai
+APP_PORT=23333

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     restart: unless-stopped
     network_mode: host
     environment:
-      TZ: Asia/Shanghai
-      APP_PORT: 23333
+      TZ: "${TZ:-Asia/Shanghai}"
+      APP_PORT: "${APP_PORT:-23333}"
     volumes:
       - /etc/hosts:/etc/hosts
       - ./config:/app/config


### PR DESCRIPTION
## Summary
- Add `.env.example` with default Docker Compose environment values.
- Let `docker-compose.yml` read `TZ` and `APP_PORT` from environment variables with defaults.

## Validation
- `docker compose config`