### PR TITLE
docs: add docker run port environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ docker run -d \
   -v /path/to/config:/app/config \
   -v /path/to/logs:/app/logs \
   -e TZ=Asia/Shanghai \
+  -e APP_PORT=23333 \
   eternalcurse/pt-accelerator:latest
 ```
 


### PR DESCRIPTION
## Summary
- Add `APP_PORT=23333` to the Docker run example so it matches the documented configurable port behavior.

## Validation
- Documentation-only change.